### PR TITLE
Improve Icecast URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Starbot Forwarder
+
+Ce bot Discord permet de recevoir l'audio d'un salon vocal et de le transmettre vers un serveur Icecast.
+
+## Utilisation
+
+```bash
+node index.js -t <token> -c <id_du_vocal> <url_icecast>
+```
+
+L'URL Icecast doit utiliser le protocole `icecast+http` ou `icecast+https` afin que ffmpeg établisse correctement la connexion. Exemple :
+
+```
+node index.js -t TOKEN -c CHANNEL_ID icecast+https://source:motdepasse@example.com/stream
+```
+
+Si l'URL commence uniquement par `http://` ou `https://`, le programme ajoutera automatiquement le préfixe `icecast+`.

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -17,19 +17,26 @@ class FFMPEG {
       'ffmpeg', '-hide_banner',
       '-f', 's16le', '-ac', '2', '-ar', '48000', '-i', 'pipe:0',
       '-ar', String(args.sampleRate),
-      '-ac', String(args.compressionLevel),
       '-c:a', 'libmp3lame',
       '-f', 'mp3'
     ];
 
+    if (args.compressionLevel > 0) {
+      cmd.push('-b:a', `${args.compressionLevel}k`);
+    }
+
     if (args.outputGroup.icecastUrl) {
+      let url = args.outputGroup.icecastUrl;
+      if (/^https?:\/\//.test(url) && !url.startsWith('icecast+')) {
+        url = 'icecast+' + url;
+      }
       cmd.push(
         '-reconnect_at_eof', '1',
         '-reconnect_streamed',  '1',
         '-reconnect',          '1',
         '-reconnect_delay_max','1000',
         '-content_type',       'audio/mpeg',
-        args.outputGroup.icecastUrl
+        url
       );
     } else if (args.outputGroup.path) {
       cmd.push(args.outputGroup.path);


### PR DESCRIPTION
## Summary
- allow HTTP Icecast URLs by prepending `icecast+`
- add optional bitrate argument for ffmpeg
- document required `icecast+` prefix in README

## Testing
- `npm install`
- `node index.js -V`
- `node index.js -t dummy -c 123 icecast+http://example.com/stream` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff2421288324af0195db354a0737