### PR TITLE
Add auto restart for ffmpeg and dynamic stream check

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@ process.on('SIGINT', () => {
 });
 
 setInterval(async () => {
-    const status = await checkStream('https://radio.libre-antenne.xyz/stream');
+    if (!args.outputGroup.icecastUrl) return;
+    const url = args.outputGroup.icecastUrl.replace(/^icecast\+/, '');
+    const status = await checkStream(url);
     if (status === 404) {
         logger.warn('Stream inaccessible (404). Redémarrage.');
         restartForwarder();


### PR DESCRIPTION
## Summary
- restart ffmpeg automatically when it exits
- allow stream availability check to use provided Icecast URL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849d8cc1abc83249c8daf137f1a5a86