### PR TITLE
Add min bitrate default and white noise fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ By default, MP3 encoding is done at 44.1 kHz. If your Icecast server or player r
 ```bash
 node index.js --token YOUR_TOKEN --channel-id VOICE_CHANNEL_ID icecast://source:password@example.org:8000/stream
 ```
+
+To avoid Icecast closing the connection during silence, a small white-noise bed
+is mixed in and a minimal bitrate of **1&nbsp;kbit/s** is enforced by default.
+Use `--min-bitrate` to override this value if needed:
+
+```bash
+node index.js --min-bitrate 2 --token YOUR_TOKEN --channel-id VOICE_CHANNEL_ID icecast://source:password@example.org:8000/stream
+```

--- a/audioReceiver.js
+++ b/audioReceiver.js
@@ -25,13 +25,17 @@ class AudioReceiver {
 
     this.inputs = new Map();
 
-    // Input de silence pour garder le flux actif
-    this.silenceInput = this.mixer.input({ channels: 2, clearInterval: 250 });
+    // Input de bruit blanc léger pour garder le flux actif
+    this.noiseInput = this.mixer.input({ channels: 2, clearInterval: 250 });
     const frameDurationMs = 20;
     const samples = this.inputSampleRate * frameDurationMs / 1000;
-    this.silenceChunk = Buffer.alloc(samples * 2 * 2); // 16-bit stereo
-    this.silenceInterval = setInterval(() => {
-      this.silenceInput.write(this.silenceChunk);
+    this.noiseInterval = setInterval(() => {
+      const buf = Buffer.alloc(samples * 2 * 2);
+      for (let i = 0; i < samples * 2; i++) {
+        const val = Math.floor((Math.random() * 2 - 1) * 500);
+        buf.writeInt16LE(val, i * 2);
+      }
+      this.noiseInput.write(buf);
     }, frameDurationMs);
 
   }
@@ -63,11 +67,11 @@ class AudioReceiver {
 
   }
 
-  /** Stoppe le générateur de silence et nettoie le mixer */
+  /** Stoppe le générateur de bruit et nettoie le mixer */
   close() {
-    clearInterval(this.silenceInterval);
-    this.mixer.removeInput(this.silenceInput);
-    this.silenceInput.destroy();
+    clearInterval(this.noiseInterval);
+    this.mixer.removeInput(this.noiseInput);
+    this.noiseInput.destroy();
   }
 }
 

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -5,8 +5,9 @@ class FFMPEG extends EventEmitter {
   /**
    * @param {object} args
    * @param {number} args.sampleRate
-   * @param {number} args.compressionLevel
-   * @param {boolean} args.redirectFfmpegOutput
+  * @param {number} args.compressionLevel
+  * @param {number|null} [args.minBitrate]
+  * @param {boolean} args.redirectFfmpegOutput
    * @param {{ icecastUrl: string|null, path: string|null }} args.outputGroup
    * @param {import('winston').Logger} logger
    */
@@ -30,6 +31,10 @@ class FFMPEG extends EventEmitter {
       '-c:a', 'libmp3lame',
       '-f', 'mp3'
     ];
+
+    if (args.minBitrate) {
+      cmd.push('-minrate', `${args.minBitrate}k`);
+    }
 
     if (args.compressionLevel > 0) {
       cmd.push('-b:a', `${args.compressionLevel}k`);

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ program
     .requiredOption('-c, --channel-id <id>', 'L’ID du canal vocal à rejoindre', process.env.CHANNEL_ID)
     .option('-r, --sample-rate <rate>', 'Sample rate de sortie (défaut 44100)', '44100')
     .option('-x, --compression-level <level>', 'Niveau de compression (défaut 0)', '0')
+    .option('--min-bitrate <kbit>', 'Bitrate minimal pour l\'encodage MP3 en kb/s (défaut 1)')
     .option('-d, --redirect-ffmpeg-output', 'Afficher stdout de ffmpeg')
     .option('-l, --listening-to <text>', 'Activité “Listening to” (défaut “you.”)', 'you.')
     .option('--railway-token <token>', 'Token API Railway', process.env.RAILWAY_TOKEN)
@@ -46,6 +47,7 @@ const args = {
     channelId: opts.channelId,
     sampleRate: parseInt(opts.sampleRate, 10),
     compressionLevel: parseInt(opts.compressionLevel, 10),
+    minBitrate: opts.minBitrate ? parseInt(opts.minBitrate, 10) : 1,
     redirectFfmpegOutput: !!opts.redirectFfmpegOutput,
     listeningTo: opts.listeningTo,
     outputGroup: {


### PR DESCRIPTION
## Summary
- default `--min-bitrate` to 1 kb/s to keep Icecast happy
- mix a low-level white-noise signal instead of silence
- document the new behaviour in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684af376c3c483248c2edf4a88e816d1