### PR TITLE
Fix WebSocket protocol for HTTPS

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2,7 +2,8 @@ let ws;
 let recorder;
 
 async function start() {
-  ws = new WebSocket(`ws://${location.host}`);
+  const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+  ws = new WebSocket(`${protocol}://${location.host}`);
   const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
   recorder = new MediaRecorder(stream, { mimeType: 'audio/webm' });
   recorder.ondataavailable = e => { if (ws.readyState === 1) ws.send(e.data); };


### PR DESCRIPTION
## Summary
- detect HTTPS protocol in frontend and use `wss` WebSocket scheme when needed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684df12ce3248324842ca6b280559854