### PR TITLE
Reduce white noise volume

### DIFF
--- a/audioReceiver.js
+++ b/audioReceiver.js
@@ -32,8 +32,9 @@ class AudioReceiver {
     this.noiseInterval = setInterval(() => {
       const buf = Buffer.alloc(samples * 2 * 2);
       for (let i = 0; i < samples * 2; i++) {
-        // White noise amplitude kept low so that it is barely audible
-        const val = Math.floor((Math.random() * 2 - 1) * 100);
+        // White noise amplitude kept low so that it is barely audible.
+        // Lowered by a factor of 4 compared to the previous value.
+        const val = Math.floor((Math.random() * 2 - 1) * 25);
         buf.writeInt16LE(val, i * 2);
       }
       this.noiseInput.write(buf);


### PR DESCRIPTION
## Summary
- lower the amplitude used to generate white noise in `audioReceiver.js`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68531be72e648324907bb8056dd129f0