### PR TITLE
Add adjustable volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ By default, MP3 encoding is done at 44.1 kHz. If your Icecast server or player r
 node index.js --token YOUR_TOKEN --channel-id VOICE_CHANNEL_ID icecast://source:password@example.org:8000/stream
 ```
 
+The audio volume is boosted to **300%** by default. Use `--volume` (or set
+`VOLUME` in your `.env` file) to adjust this multiplier:
+
+```bash
+node index.js --volume 1.5 --token YOUR_TOKEN --channel-id VOICE_CHANNEL_ID icecast://source:password@example.org:8000/stream
+```
+
 To avoid Icecast closing the connection during silence, a small white-noise bed
 is mixed in and a minimal bitrate of **1&nbsp;kbit/s** is enforced by default.
 Use `--min-bitrate` to override this value if needed:

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -6,6 +6,7 @@ class FFMPEG extends EventEmitter {
    * @param {object} args
    * @param {number} args.sampleRate
   * @param {number} args.compressionLevel
+  * @param {number} args.volume
   * @param {number|null} [args.minBitrate]
   * @param {boolean} args.redirectFfmpegOutput
    * @param {{ icecastUrl: string|null, path: string|null }} args.outputGroup
@@ -26,7 +27,7 @@ class FFMPEG extends EventEmitter {
     const cmd = [
       'ffmpeg', '-hide_banner',
       '-f', 's16le', '-ac', '2', '-ar', '48000', '-i', 'pipe:0',
-      '-filter:a', 'volume=2',
+      '-filter:a', `volume=${args.volume}`,
       '-ar', String(args.sampleRate),
       '-ac', '2',
       '-c:a', 'libmp3lame',

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ program
     .option('--min-bitrate <kbit>', 'Bitrate minimal pour l\'encodage MP3 en kb/s (défaut 1)')
     .option('-d, --redirect-ffmpeg-output', 'Afficher stdout de ffmpeg')
     .option('-l, --listening-to <text>', 'Activité “Listening to” (défaut “you.”)', 'you.')
+    .option('-v, --volume <multiplier>', 'Multiplicateur de volume (défaut 3)', process.env.VOLUME || '3')
     .option('--railway-token <token>', 'Token API Railway', process.env.RAILWAY_TOKEN)
     .option('--railway-project <id>', 'ID du projet Railway', process.env.RAILWAY_PROJECT_ID)
     .option('--railway-environment <id>', 'ID de l\'environnement Railway', process.env.RAILWAY_ENVIRONMENT_ID)
@@ -51,6 +52,7 @@ const args = {
     sampleRate: parseInt(opts.sampleRate, 10),
     compressionLevel: parseInt(opts.compressionLevel, 10),
     minBitrate: opts.minBitrate ? parseInt(opts.minBitrate, 10) : 1,
+    volume: parseFloat(opts.volume),
     redirectFfmpegOutput: !!opts.redirectFfmpegOutput,
     listeningTo: opts.listeningTo,
     web: opts.web,


### PR DESCRIPTION
## Summary
- make FFmpeg volume boost configurable
- allow specifying volume through CLI and env variable
- update docs about new `--volume` option

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685805dfc58483248a45d40dbaa6a3a4