### PR TITLE
Add delayed reconnect after kick

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-This Discord bot captures audio from a voice channel and forwards it to an Icecast server. Multiple users can speak at the same time: the audio is automatically mixed.
+This Discord bot captures audio from a voice channel and forwards it to an Icecast server. Multiple users can speak at the same time: the audio is automatically mixed. If the bot is kicked from the voice channel, it will reconnect automatically after **30&nbsp;minutes**.
 
 ## Usage 
 


### PR DESCRIPTION
## Summary
- delay reconnection for 30 minutes if the bot gets kicked from the voice channel
- document this behaviour in the README

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a9943ba608324b79f8307d7025790