### PR TITLE
Disable self mute by default

### DIFF
--- a/forwarder.js
+++ b/forwarder.js
@@ -74,7 +74,7 @@ class Forwarder {
             channelId: channel.id,
             guildId: channel.guild.id,
             adapterCreator: channel.guild.voiceAdapterCreator,
-            selfMute: true,
+            selfMute: false,
             selfDeaf: false
         });
         this.connection.subscribe(this.audioPlayer);


### PR DESCRIPTION
## Summary
- set the Discord voice connection to join channels without self-muting so it can transmit audio immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83b612f38832485100e9949778ed2