### PR TITLE
Stream Discord audio to Kaldi transcription server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Use `--min-bitrate` to override this value if needed:
 node index.js --min-bitrate 2 --token YOUR_TOKEN --channel-id VOICE_CHANNEL_ID icecast://source:password@example.org:8000/stream
 ```
 
+## Transcription temps réel via Kaldi
+
+Chaque participant est maintenant retranscrit en temps réel via WebSocket vers un
+serveur Kaldi (par défaut `ws://kaldiws.internal/client/ws/speech`). Utilisez les
+options suivantes pour personnaliser ou désactiver cette fonctionnalité :
+
+```bash
+node index.js --kaldi-ws ws://kaldiws.internal/client/ws/speech \
+  --kaldi-sample-rate 16000 \
+  --kaldi-language fr-FR \
+  -t YOUR_TOKEN -c VOICE_CHANNEL_ID icecast://source:password@example.org:8000/stream
+```
+
+Ajoutez `--kaldi-disable` (ou la variable d’environnement `KALDI_DISABLE=true`)
+si vous ne souhaitez pas transmettre les flux audio vers Kaldi.
+
 The white-noise generator in `audioReceiver.js` writes very low-level samples
 (amplitude around `±100`). Adjust this constant if you need the noise to be
 more or less audible.

--- a/audioReceiver.js
+++ b/audioReceiver.js
@@ -1,16 +1,19 @@
 const prism = require('prism-media');
 const AudioMixer = require('audio-mixer');
+const KaldiStream = require('./kaldiClient');
 
 class AudioReceiver {
   /**
    * @param {FFMPEG} ffmpegInstance
    * @param {number} inputSampleRate
    * @param {import('winston').Logger} logger
+   * @param {{ wsUrl: string, sampleRate: number, language?: string }|null} kaldiConfig
    */
-  constructor(ffmpegInstance, inputSampleRate, logger) {
+  constructor(ffmpegInstance, inputSampleRate, logger, kaldiConfig) {
     this.ffmpeg = ffmpegInstance;
     this.logger = logger;
     this.inputSampleRate = inputSampleRate;
+    this.kaldiConfig = kaldiConfig && kaldiConfig.wsUrl ? kaldiConfig : null;
 
     // Mixer pour combiner les flux de plusieurs utilisateurs
     this.mixer = new AudioMixer.Mixer({
@@ -24,6 +27,7 @@ class AudioReceiver {
     });
 
     this.inputs = new Map();
+    this.kaldiStreams = new Map();
 
     // Input de bruit blanc léger pour garder le flux actif
     this.noiseInput = this.mixer.input({ channels: 2, clearInterval: 250 });
@@ -53,16 +57,44 @@ class AudioReceiver {
 
     const decoder = new prism.opus.Decoder({ channels: 2, rate: this.inputSampleRate, frameSize: 960 });
     const input = this.mixer.input({ channels: 2 });
+    let kaldiStream = null;
+    if (this.kaldiConfig) {
+      try {
+        kaldiStream = new KaldiStream(userId, this.kaldiConfig, this.logger);
+        this.kaldiStreams.set(userId, kaldiStream);
+      } catch (err) {
+        this.logger.error(`Kaldi stream creation failed for ${userId}: ${err.message}`);
+      }
+    }
 
-    decoder.on('data', chunk => input.write(chunk));
+    decoder.on('data', chunk => {
+      input.write(chunk);
+      if (kaldiStream) {
+        kaldiStream.sendAudio(chunk, this.inputSampleRate);
+      }
+    });
     decoder.on('error', err => this.logger.error('Opus decoder error:', err));
     opusStream.pipe(decoder);
 
-    opusStream.once('end', () => {
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
       this.mixer.removeInput(input);
       input.destroy();
       decoder.destroy();
       this.inputs.delete(userId);
+      if (kaldiStream) {
+        kaldiStream.finish();
+        this.kaldiStreams.delete(userId);
+      }
+    };
+
+    opusStream.once('end', cleanup);
+    opusStream.once('close', cleanup);
+    opusStream.once('error', err => {
+      this.logger.error(`Opus stream error for ${userId}: ${err.message || err}`);
+      cleanup();
     });
 
     this.inputs.set(userId, { decoder, input });
@@ -74,6 +106,10 @@ class AudioReceiver {
     clearInterval(this.noiseInterval);
     this.mixer.removeInput(this.noiseInput);
     this.noiseInput.destroy();
+    for (const stream of this.kaldiStreams.values()) {
+      stream.close();
+    }
+    this.kaldiStreams.clear();
   }
 }
 

--- a/forwarder.js
+++ b/forwarder.js
@@ -98,8 +98,8 @@ class Forwarder {
         });
 
         if (!this.receiver) {
-            // créé un AudioReceiver qui enverra tout dans ffmpeg
-            this.receiver = new AudioReceiver(this.ffmpeg, 48000, this.logger);
+            // créé un AudioReceiver qui enverra tout dans ffmpeg et vers Kaldi
+            this.receiver = new AudioReceiver(this.ffmpeg, 48000, this.logger, this.args.kaldi);
         }
 
         // à chaque fois qu’un user parle, on pipe son flux Opus vers notre décodeur

--- a/index.js
+++ b/index.js
@@ -26,11 +26,22 @@ program
     .option('--railway-service <id>', 'ID du service Railway', process.env.RAILWAY_SERVICE_ID)
     .option('--web', 'Expose une page web pour parler', process.env.WEB === 'true')
     .option('--web-port <port>', 'Port du serveur web (défaut 3000)', process.env.WEB_PORT || '3000')
+    .option('--kaldi-ws <url>', 'URL du serveur Kaldi WebSocket (défaut ws://kaldiws.internal/client/ws/speech)')
+    .option('--kaldi-sample-rate <hz>', 'Sample rate à envoyer à Kaldi (défaut 16000)')
+    .option('--kaldi-language <lang>', 'Langue à annoncer au serveur Kaldi (optionnel)')
+    .option('--kaldi-disable', 'Désactive la retranscription Kaldi')
     .argument('[icecastUrl]', 'URL Icecast de destination')
     .argument('[fileOutput]', 'Chemin de fichier local en alternative')
     .parse(process.argv);
 
 const opts = program.opts();
+const kaldiDisabled = opts.kaldiDisable || process.env.KALDI_DISABLE === 'true';
+const kaldiWsUrl = kaldiDisabled ? null : (opts.kaldiWs || process.env.KALDI_WS_URL || 'ws://kaldiws.internal/client/ws/speech');
+let kaldiSampleRate = parseInt(opts.kaldiSampleRate || process.env.KALDI_SAMPLE_RATE || '16000', 10);
+if (!Number.isFinite(kaldiSampleRate) || kaldiSampleRate <= 0) {
+    kaldiSampleRate = 16000;
+}
+const kaldiLanguage = opts.kaldiLanguage || process.env.KALDI_LANGUAGE;
 let [icecastUrl, fileOutput] = program.args;
 if (!icecastUrl) {
     icecastUrl = process.env.ICECAST_URL;
@@ -57,6 +68,11 @@ const args = {
     listeningTo: opts.listeningTo,
     web: opts.web,
     webPort: parseInt(opts.webPort, 10),
+    kaldi: kaldiWsUrl ? {
+        wsUrl: kaldiWsUrl,
+        sampleRate: kaldiSampleRate,
+        language: kaldiLanguage || undefined
+    } : null,
     outputGroup: {
         icecastUrl,
         path: fileOutput || null

--- a/kaldiClient.js
+++ b/kaldiClient.js
@@ -1,0 +1,198 @@
+const WebSocket = require('ws');
+
+function clamp16(value) {
+  if (value > 32767) return 32767;
+  if (value < -32768) return -32768;
+  return value;
+}
+
+function downsampleStereo(buffer, inputRate, outputRate) {
+  const channels = 2;
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    return Buffer.alloc(0);
+  }
+  if (!outputRate || outputRate >= inputRate) {
+    // Only convert to mono without resampling
+    const frameCount = buffer.length / 2 / channels;
+    const out = Buffer.alloc(frameCount * 2);
+    let offset = 0;
+    for (let i = 0; i < frameCount; i++) {
+      const baseIndex = i * channels * 2;
+      const left = buffer.readInt16LE(baseIndex);
+      const right = buffer.readInt16LE(baseIndex + 2);
+      const mono = clamp16(Math.round((left + right) / 2));
+      out.writeInt16LE(mono, offset);
+      offset += 2;
+    }
+    return out.slice(0, offset);
+  }
+
+  const ratio = inputRate / outputRate;
+  const frameCount = buffer.length / 2 / channels;
+  const outputFrameCount = Math.floor(frameCount / ratio);
+  const out = Buffer.alloc(outputFrameCount * 2);
+  let offset = 0;
+
+  for (let i = 0; i < outputFrameCount; i++) {
+    const start = Math.floor(i * ratio);
+    const end = Math.min(Math.floor((i + 1) * ratio), frameCount);
+    if (start >= frameCount) break;
+    let sum = 0;
+    let samples = 0;
+    for (let j = start; j < end; j++) {
+      const baseIndex = j * channels * 2;
+      const left = buffer.readInt16LE(baseIndex);
+      const right = buffer.readInt16LE(baseIndex + 2);
+      sum += (left + right) / 2;
+      samples++;
+    }
+    if (samples === 0) continue;
+    const mono = clamp16(Math.round(sum / samples));
+    out.writeInt16LE(mono, offset);
+    offset += 2;
+  }
+
+  return out.slice(0, offset);
+}
+
+class KaldiStream {
+  constructor(userId, config, logger) {
+    this.userId = userId;
+    this.logger = logger;
+    this.config = {
+      wsUrl: config.wsUrl,
+      sampleRate: config.sampleRate || 16000,
+      language: config.language
+    };
+    this.queue = [];
+    this.closed = false;
+    this.hasSentConfig = false;
+
+    this.ws = new WebSocket(this.config.wsUrl, {
+      perMessageDeflate: false
+    });
+
+    this.ws.on('open', () => {
+      this.logger.debug(`🔁 [Kaldi] Connexion ouverte pour ${this.userId}`);
+      this.sendConfig();
+      this.flushQueue();
+    });
+
+    this.ws.on('message', data => {
+      this.handleMessage(data);
+    });
+
+    this.ws.on('error', err => {
+      if (this.closed) return;
+      this.logger.error(`❌ [Kaldi] Erreur pour ${this.userId}: ${err.message}`);
+    });
+
+    this.ws.on('close', code => {
+      this.logger.debug(`🔁 [Kaldi] Connexion fermée pour ${this.userId} (code ${code})`);
+    });
+  }
+
+  sendConfig() {
+    if (this.hasSentConfig) return;
+    const payload = { config: { sample_rate: this.config.sampleRate } };
+    if (this.config.language) {
+      payload.config.language = this.config.language;
+    }
+    const message = JSON.stringify(payload);
+    this.hasSentConfig = true;
+    if (this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(message);
+    } else if (this.ws.readyState === WebSocket.CONNECTING) {
+      this.queue.unshift({ type: 'text', payload: message });
+    }
+  }
+
+  sendMessage(type, payload) {
+    if (this.closed) return;
+    if (this.ws.readyState === WebSocket.OPEN) {
+      if (type === 'binary') {
+        this.ws.send(payload);
+      } else {
+        this.ws.send(payload);
+      }
+    } else if (this.ws.readyState === WebSocket.CONNECTING) {
+      this.queue.push({ type, payload });
+    }
+  }
+
+  flushQueue() {
+    if (this.ws.readyState !== WebSocket.OPEN) return;
+    for (const item of this.queue) {
+      if (item.type === 'binary') {
+        this.ws.send(item.payload);
+      } else {
+        this.ws.send(item.payload);
+      }
+    }
+    this.queue = [];
+  }
+
+  sendAudio(buffer, inputSampleRate) {
+    if (this.closed) return;
+    const pcm = downsampleStereo(buffer, inputSampleRate, this.config.sampleRate);
+    if (pcm.length === 0) return;
+    this.sendMessage('binary', pcm);
+  }
+
+  finish() {
+    if (this.closed) return;
+    this.closed = true;
+    this.queue = this.queue.filter(item => item.type === 'text');
+    const sendEofAndClose = () => {
+      try {
+        this.ws.send(JSON.stringify({ eof: 1 }));
+      } catch (err) {
+        this.logger.warn(`⚠️ [Kaldi] Impossible d'envoyer EOF pour ${this.userId}: ${err.message}`);
+      }
+      setTimeout(() => {
+        try { this.ws.close(); } catch {}
+      }, 250);
+    };
+
+    if (this.ws.readyState === WebSocket.OPEN) {
+      sendEofAndClose();
+    } else if (this.ws.readyState === WebSocket.CONNECTING) {
+      this.ws.once('open', sendEofAndClose);
+      this.ws.once('error', () => {
+        try { this.ws.close(); } catch {}
+      });
+    } else {
+      try { this.ws.close(); } catch {}
+    }
+  }
+
+  handleMessage(data) {
+    if (this.closed) return;
+    if (typeof data !== 'string') {
+      return;
+    }
+    try {
+      const msg = JSON.parse(data);
+      if (msg?.result?.hypotheses?.length) {
+        const hypothesis = msg.result.hypotheses[0];
+        if (msg.result.final) {
+          this.logger.info(`📝 [Kaldi][${this.userId}] ${hypothesis.transcript}`);
+        } else {
+          this.logger.debug(`🗒️ [Kaldi][${this.userId}] ${hypothesis.transcript}`);
+        }
+      }
+    } catch (err) {
+      this.logger.warn(`⚠️ [Kaldi] Message inattendu pour ${this.userId}: ${err.message}`);
+    }
+  }
+
+  close() {
+    if (this.closed) {
+      try { this.ws.close(); } catch {}
+      return;
+    }
+    this.finish();
+  }
+}
+
+module.exports = KaldiStream;


### PR DESCRIPTION
## Summary
- add a Kaldi streaming client to send per-user PCM audio over WebSocket for transcription
- wire the audio receiver to fork decoded audio toward both ffmpeg and Kaldi, with cleanup on stream end
- add CLI options and documentation for configuring or disabling the Kaldi connection

## Testing
- node -e "require('./kaldiClient')"
- node -e "require('./audioReceiver')"

------
https://chatgpt.com/codex/tasks/task_e_68cd916b35f483249e8138e239ae9e84