### PR TITLE
Store Kaldi transcripts in Postgres and expose REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ node index.js --kaldi-ws ws://kaldiws.internal/client/ws/speech \
 Ajoutez `--kaldi-disable` (ou la variable d’environnement `KALDI_DISABLE=true`)
 si vous ne souhaitez pas transmettre les flux audio vers Kaldi.
 
+### Stockage PostgreSQL des transcriptions
+
+Fournissez une URL de connexion PostgreSQL (`--pg-url` ou la variable d’environnement
+`POSTGRES_URL`/`DATABASE_URL`) pour que chaque transcription finale soit enregistrée
+avec l’identifiant Discord de l’utilisateur, le texte reconnu et un horodatage précis.
+Activez l’option `--pg-ssl` (ou définissez `POSTGRES_SSL=true`) si votre fournisseur
+demande une connexion chiffrée. La table `voice_transcriptions` est créée
+automatiquement si elle n’existe pas.
+
+Une API REST est exposée sur le même port que l’interface web (ou sur `--web-port` si
+vous n’activez pas l’interface). Deux endpoints sont disponibles :
+
+- `GET /api/transcriptions?limit=50` retourne les dernières transcriptions tous
+  utilisateurs confondus (limite maximale : 200).
+- `GET /api/transcriptions/:userId?limit=50` renvoie les dernières transcriptions
+  associées à un utilisateur précis.
+
 The white-noise generator in `audioReceiver.js` writes very low-level samples
 (amplitude around `±100`). Adjust this constant if you need the noise to be
 more or less audible.

--- a/audioReceiver.js
+++ b/audioReceiver.js
@@ -8,12 +8,14 @@ class AudioReceiver {
    * @param {number} inputSampleRate
    * @param {import('winston').Logger} logger
    * @param {{ wsUrl: string, sampleRate: number, language?: string }|null} kaldiConfig
+   * @param {import('./transcriptionStore').TranscriptionStore|null} transcriptionStore
    */
-  constructor(ffmpegInstance, inputSampleRate, logger, kaldiConfig) {
+  constructor(ffmpegInstance, inputSampleRate, logger, kaldiConfig, transcriptionStore) {
     this.ffmpeg = ffmpegInstance;
     this.logger = logger;
     this.inputSampleRate = inputSampleRate;
     this.kaldiConfig = kaldiConfig && kaldiConfig.wsUrl ? kaldiConfig : null;
+    this.transcriptionStore = transcriptionStore || null;
 
     // Mixer pour combiner les flux de plusieurs utilisateurs
     this.mixer = new AudioMixer.Mixer({
@@ -60,7 +62,7 @@ class AudioReceiver {
     let kaldiStream = null;
     if (this.kaldiConfig) {
       try {
-        kaldiStream = new KaldiStream(userId, this.kaldiConfig, this.logger);
+        kaldiStream = new KaldiStream(userId, this.kaldiConfig, this.logger, this.transcriptionStore);
         this.kaldiStreams.set(userId, kaldiStream);
       } catch (err) {
         this.logger.error(`Kaldi stream creation failed for ${userId}: ${err.message}`);

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -66,7 +66,7 @@ class FFMPEG extends EventEmitter {
       stdio: [
         'pipe',
         args.redirectFfmpegOutput ? 'inherit' : 'ignore',
-        'inherit'
+        args.redirectFfmpegOutput ? 'inherit' : 'ignore'
       ]
     });
 

--- a/forwarder.js
+++ b/forwarder.js
@@ -99,7 +99,7 @@ class Forwarder {
 
         if (!this.receiver) {
             // créé un AudioReceiver qui enverra tout dans ffmpeg et vers Kaldi
-            this.receiver = new AudioReceiver(this.ffmpeg, 48000, this.logger, this.args.kaldi);
+            this.receiver = new AudioReceiver(this.ffmpeg, 48000, this.logger, this.args.kaldi, this.args.transcriptionStore || null);
         }
 
         // à chaque fois qu’un user parle, on pipe son flux Opus vers notre décodeur

--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ const http = require('http');
 const https = require('https');
 const Forwarder = require('./forwarder');
 const getVersion = require('./version');
-const startWebServer = require("./webServer");
+const startWebServer = require('./webServer');
+const { createTranscriptionStore } = require('./transcriptionStore');
+
+const envFlag = value => typeof value === 'string' && ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
 
 program
     .name('node index.js')
@@ -17,7 +20,7 @@ program
     .option('-r, --sample-rate <rate>', 'Sample rate de sortie (défaut 44100)', '44100')
     .option('-x, --compression-level <level>', 'Niveau de compression (défaut 0)', '0')
     .option('--min-bitrate <kbit>', 'Bitrate minimal pour l\'encodage MP3 en kb/s (défaut 1)')
-    .option('-d, --redirect-ffmpeg-output', 'Afficher stdout de ffmpeg')
+    .option('-d, --redirect-ffmpeg-output', 'Afficher la sortie de ffmpeg dans la console')
     .option('-l, --listening-to <text>', 'Activité “Listening to” (défaut “you.”)', 'you.')
     .option('-v, --volume <multiplier>', 'Multiplicateur de volume (défaut 3)', process.env.VOLUME || '3')
     .option('--railway-token <token>', 'Token API Railway', process.env.RAILWAY_TOKEN)
@@ -28,8 +31,10 @@ program
     .option('--web-port <port>', 'Port du serveur web (défaut 3000)', process.env.WEB_PORT || '3000')
     .option('--kaldi-ws <url>', 'URL du serveur Kaldi WebSocket (défaut ws://kaldiws.internal/client/ws/speech)')
     .option('--kaldi-sample-rate <hz>', 'Sample rate à envoyer à Kaldi (défaut 16000)')
-    .option('--kaldi-language <lang>', 'Langue à annoncer au serveur Kaldi (optionnel)')
+    .option('--kaldi-language <lang>', 'Langue à annoncer au serveur Kaldi (défaut fr-FR)')
     .option('--kaldi-disable', 'Désactive la retranscription Kaldi')
+    .option('--pg-url <url>', 'URL de connexion Postgres', process.env.POSTGRES_URL || process.env.DATABASE_URL)
+    .option('--pg-ssl', 'Active SSL pour la connexion Postgres')
     .argument('[icecastUrl]', 'URL Icecast de destination')
     .argument('[fileOutput]', 'Chemin de fichier local en alternative')
     .parse(process.argv);
@@ -41,7 +46,9 @@ let kaldiSampleRate = parseInt(opts.kaldiSampleRate || process.env.KALDI_SAMPLE_
 if (!Number.isFinite(kaldiSampleRate) || kaldiSampleRate <= 0) {
     kaldiSampleRate = 16000;
 }
-const kaldiLanguage = opts.kaldiLanguage || process.env.KALDI_LANGUAGE;
+const kaldiLanguage = opts.kaldiLanguage || process.env.KALDI_LANGUAGE || 'fr-FR';
+const pgUrl = opts.pgUrl || process.env.POSTGRES_URL || process.env.DATABASE_URL;
+const pgSsl = Boolean(opts.pgSsl || envFlag(process.env.POSTGRES_SSL) || envFlag(process.env.PGSSL) || envFlag(process.env.PG_SSL));
 let [icecastUrl, fileOutput] = program.args;
 if (!icecastUrl) {
     icecastUrl = process.env.ICECAST_URL;
@@ -71,8 +78,9 @@ const args = {
     kaldi: kaldiWsUrl ? {
         wsUrl: kaldiWsUrl,
         sampleRate: kaldiSampleRate,
-        language: kaldiLanguage || undefined
+        language: kaldiLanguage
     } : null,
+    transcriptionStore: null,
     outputGroup: {
         icecastUrl,
         path: fileOutput || null
@@ -86,17 +94,29 @@ const args = {
 };
 
 let forwarder;
+let webServerController = null;
+
+function ensureWebServer() {
+    if (!webServerController && (args.web || args.transcriptionStore)) {
+        webServerController = startWebServer(forwarder, args.webPort, logger, {
+            enableWebClient: args.web,
+            transcriptionStore: args.transcriptionStore || null
+        });
+    } else if (webServerController) {
+        webServerController.updateForwarder(forwarder);
+    }
+}
 
 function startForwarder() {
     forwarder = new Forwarder(args, logger);
     logger.info('Forwarder démarré. CTRL-C pour quitter.');
+    ensureWebServer();
 }
 
 function restartForwarder() {
     logger.warn('Redémarrage du forwarder…');
     if (forwarder) forwarder.close();
     startForwarder();
-    if (args.web) startWebServer(forwarder, args.webPort, logger);
 }
 
 async function triggerRailwayRestart(cfg) {
@@ -148,13 +168,43 @@ function checkStream(url) {
     });
 }
 
-startForwarder();
-if (args.web) startWebServer(forwarder, args.webPort, logger);
+async function main() {
+    if (pgUrl) {
+        try {
+            const storeOptions = { connectionString: pgUrl };
+            if (pgSsl) {
+                storeOptions.ssl = { rejectUnauthorized: false };
+            }
+            args.transcriptionStore = await createTranscriptionStore(storeOptions, logger);
+        } catch (err) {
+            logger.error(`❌ Impossible d'initialiser Postgres: ${err.message}`);
+        }
+    } else {
+        logger.warn('⚠️ Aucune base Postgres configurée : les transcriptions ne seront pas stockées.');
+    }
+    startForwarder();
+}
+
+main().catch(err => {
+    logger.error(`❌ Erreur fatale lors du démarrage: ${err.message}`);
+    process.exit(1);
+});
 
 process.on('SIGINT', () => {
     logger.info('Arrêt en cours…');
     if (forwarder) forwarder.close();
-    process.exit(0);
+    const tasks = [];
+    if (webServerController) {
+        tasks.push(webServerController.close().catch(err => {
+            logger.error(`❌ Erreur lors de l'arrêt du serveur web: ${err.message}`);
+        }));
+    }
+    if (args.transcriptionStore) {
+        tasks.push(args.transcriptionStore.close().catch(err => {
+            logger.error(`❌ Erreur lors de la fermeture de Postgres: ${err.message}`);
+        }));
+    }
+    Promise.all(tasks).finally(() => process.exit(0));
 });
 
 setInterval(async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^5.1.0",
         "ffmpeg-static": "^5.2.0",
         "opusscript": "^0.0.8",
+        "pg": "^8.16.3",
         "prism-media": "^1.3.5",
         "winston": "^3.17.0",
         "ws": "^8.18.2"
@@ -1560,6 +1561,134 @@
         "node": ">=16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
@@ -1876,6 +2005,15 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -2139,6 +2277,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express": "^5.1.0",
     "ffmpeg-static": "^5.2.0",
     "opusscript": "^0.0.8",
+    "pg": "^8.16.3",
     "prism-media": "^1.3.5",
     "winston": "^3.17.0",
     "ws": "^8.18.2"

--- a/transcriptionStore.js
+++ b/transcriptionStore.js
@@ -1,0 +1,97 @@
+const { Pool } = require('pg');
+
+class TranscriptionStore {
+  /**
+   * @param {import('pg').PoolConfig} config
+   * @param {import('winston').Logger} logger
+   */
+  constructor(config, logger) {
+    this.logger = logger;
+    this.pool = new Pool(config);
+  }
+
+  /**
+   * Initialise la table en base de données.
+   */
+  async init() {
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS voice_transcriptions (
+        id BIGSERIAL PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        transcript TEXT NOT NULL,
+        confidence REAL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+  }
+
+  /**
+   * @param {string} userId
+   * @param {string} transcript
+   * @param {number|undefined} confidence
+   * @param {Date} [createdAt]
+   */
+  async saveTranscription(userId, transcript, confidence, createdAt = new Date()) {
+    if (!userId || !transcript) return;
+    await this.pool.query(
+      'INSERT INTO voice_transcriptions (user_id, transcript, confidence, created_at) VALUES ($1, $2, $3, $4)',
+      [userId, transcript, confidence ?? null, createdAt]
+    );
+  }
+
+  /**
+   * @param {number} limit
+   */
+  async getLatest(limit) {
+    const { rows } = await this.pool.query(
+      'SELECT user_id, transcript, confidence, created_at FROM voice_transcriptions ORDER BY created_at DESC LIMIT $1',
+      [limit]
+    );
+    return rows.map(row => ({
+      userId: row.user_id,
+      transcript: row.transcript,
+      confidence: row.confidence,
+      createdAt: row.created_at
+    }));
+  }
+
+  /**
+   * @param {string} userId
+   * @param {number} limit
+   */
+  async getLatestForUser(userId, limit) {
+    const { rows } = await this.pool.query(
+      'SELECT user_id, transcript, confidence, created_at FROM voice_transcriptions WHERE user_id = $1 ORDER BY created_at DESC LIMIT $2',
+      [userId, limit]
+    );
+    return rows.map(row => ({
+      userId: row.user_id,
+      transcript: row.transcript,
+      confidence: row.confidence,
+      createdAt: row.created_at
+    }));
+  }
+
+  async close() {
+    await this.pool.end();
+  }
+}
+
+async function createTranscriptionStore(options, logger) {
+  if (!options?.connectionString && !options?.config) {
+    logger.warn('⚠️ Aucune URL Postgres fournie, stockage des transcriptions désactivé.');
+    return null;
+  }
+
+  const config = options.config || { connectionString: options.connectionString, ssl: options.ssl }; // ssl peut être undefined
+  const store = new TranscriptionStore(config, logger);
+  await store.init();
+  logger.info('✅ Connexion Postgres initialisée.');
+  return store;
+}
+
+module.exports = {
+  TranscriptionStore,
+  createTranscriptionStore
+};
+

--- a/webServer.js
+++ b/webServer.js
@@ -3,28 +3,103 @@ const { WebSocketServer } = require('ws');
 const path = require('path');
 const { PassThrough } = require('stream');
 
+/** @typedef {import('./forwarder')} Forwarder */
+
 /**
- * Démarre le serveur web permettant d'envoyer de l'audio au bot.
+ * Démarre le serveur web (interface + API) permettant d'envoyer de l'audio au bot.
  * @param {Forwarder} forwarder
  * @param {number} port
  * @param {import('winston').Logger} logger
+ * @param {{ enableWebClient?: boolean, transcriptionStore?: import('./transcriptionStore').TranscriptionStore|null }} [options]
  */
-function startWebServer(forwarder, port, logger) {
+function startWebServer(forwarder, port, logger, options = {}) {
+  const { enableWebClient = false, transcriptionStore = null } = options;
+  let currentForwarder = forwarder;
+
   const app = express();
-  app.use(express.static(path.join(__dirname, 'public')));
-  const server = app.listen(port, () => logger.info(`Serveur web sur le port ${port}`));
-  const wss = new WebSocketServer({ server });
 
-  wss.on('connection', ws => {
-    logger.info('Client WebSocket connecté');
-    const stream = new PassThrough();
-    forwarder.playStream(stream);
+  const parseLimit = (value) => {
+    const raw = Array.isArray(value) ? value[0] : value;
+    const parsed = parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return 50;
+    return Math.min(parsed, 200);
+  };
 
-    ws.on('message', data => {
-      if (Buffer.isBuffer(data)) stream.write(data);
-    });
-    ws.on('close', () => stream.end());
+  const formatRows = rows => rows.map(item => ({
+    userId: item.userId,
+    transcript: item.transcript,
+    confidence: item.confidence,
+    createdAt: item.createdAt instanceof Date ? item.createdAt.toISOString() : new Date(item.createdAt).toISOString()
+  }));
+
+  app.get('/api/transcriptions', async (req, res) => {
+    if (!transcriptionStore) {
+      return res.status(503).json({ error: 'Le stockage des transcriptions est désactivé.' });
+    }
+    try {
+      const limit = parseLimit(req.query.limit);
+      const items = await transcriptionStore.getLatest(limit);
+      res.json(formatRows(items));
+    } catch (err) {
+      logger.error(`❌ [API] Impossible de récupérer les transcriptions: ${err.message}`);
+      res.status(500).json({ error: 'Erreur interne lors de la récupération des transcriptions.' });
+    }
   });
+
+  app.get('/api/transcriptions/:userId', async (req, res) => {
+    if (!transcriptionStore) {
+      return res.status(503).json({ error: 'Le stockage des transcriptions est désactivé.' });
+    }
+    try {
+      const limit = parseLimit(req.query.limit);
+      const items = await transcriptionStore.getLatestForUser(req.params.userId, limit);
+      res.json(formatRows(items));
+    } catch (err) {
+      logger.error(`❌ [API] Impossible de récupérer les transcriptions pour ${req.params.userId}: ${err.message}`);
+      res.status(500).json({ error: 'Erreur interne lors de la récupération des transcriptions.' });
+    }
+  });
+
+  if (enableWebClient) {
+    app.use(express.static(path.join(__dirname, 'public')));
+  }
+
+  const server = app.listen(port, () => logger.info(`Serveur web sur le port ${port}`));
+  let wss = null;
+
+  if (enableWebClient) {
+    wss = new WebSocketServer({ server });
+
+    wss.on('connection', ws => {
+      logger.info('Client WebSocket connecté');
+      const stream = new PassThrough();
+      if (currentForwarder && typeof currentForwarder.playStream === 'function') {
+        currentForwarder.playStream(stream);
+      } else {
+        logger.warn('⚠️ Aucun forwarder actif pour relayer le flux WebSocket.');
+      }
+
+      ws.on('message', data => {
+        if (Buffer.isBuffer(data)) stream.write(data);
+      });
+      ws.on('close', () => stream.end());
+    });
+  }
+
+  return {
+    updateForwarder(nextForwarder) {
+      currentForwarder = nextForwarder;
+    },
+    async close() {
+      if (wss) {
+        for (const client of wss.clients) {
+          try { client.terminate(); } catch (_) {}
+        }
+        await new Promise(resolve => wss.close(resolve));
+      }
+      await new Promise(resolve => server.close(resolve));
+    }
+  };
 }
 
 module.exports = startWebServer;


### PR DESCRIPTION
## Summary
- persist final Kaldi transcripts in PostgreSQL with configurable connection options and automatic table setup
- expose REST endpoints on the existing web server to retrieve the latest transcriptions globally or per user while keeping the web relay optional
- default Kaldi to French, silence ffmpeg output unless explicitly requested, and document the new configuration knobs

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cda12bece88324b815ba18d14a82d0