### PR TITLE
Fix default Kaldi WebSocket URL for exposed port

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ node index.js --min-bitrate 2 --token YOUR_TOKEN --channel-id VOICE_CHANNEL_ID i
 ## Transcription temps réel via Kaldi
 
 Chaque participant est maintenant retranscrit en temps réel via WebSocket vers un
-serveur Kaldi (par défaut `ws://kaldiws.internal/client/ws/speech`). Utilisez les
+serveur Kaldi (par défaut `ws://kaldiws.internal:2700/client/ws/speech`). Utilisez les
 options suivantes pour personnaliser ou désactiver cette fonctionnalité :
 
 ```bash
-node index.js --kaldi-ws ws://kaldiws.internal/client/ws/speech \
+node index.js --kaldi-ws ws://kaldiws.internal:2700/client/ws/speech \
   --kaldi-sample-rate 16000 \
   --kaldi-language fr-FR \
   -t YOUR_TOKEN -c VOICE_CHANNEL_ID icecast://source:password@example.org:8000/stream

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ program
     .option('--railway-service <id>', 'ID du service Railway', process.env.RAILWAY_SERVICE_ID)
     .option('--web', 'Expose une page web pour parler', process.env.WEB === 'true')
     .option('--web-port <port>', 'Port du serveur web (défaut 3000)', process.env.WEB_PORT || '3000')
-    .option('--kaldi-ws <url>', 'URL du serveur Kaldi WebSocket (défaut ws://kaldiws.internal/client/ws/speech)')
+    .option('--kaldi-ws <url>', 'URL du serveur Kaldi WebSocket (défaut ws://kaldiws.internal:2700/client/ws/speech)')
     .option('--kaldi-sample-rate <hz>', 'Sample rate à envoyer à Kaldi (défaut 16000)')
     .option('--kaldi-language <lang>', 'Langue à annoncer au serveur Kaldi (défaut fr-FR)')
     .option('--kaldi-disable', 'Désactive la retranscription Kaldi')
@@ -41,7 +41,7 @@ program
 
 const opts = program.opts();
 const kaldiDisabled = opts.kaldiDisable || process.env.KALDI_DISABLE === 'true';
-const kaldiWsUrl = kaldiDisabled ? null : (opts.kaldiWs || process.env.KALDI_WS_URL || 'ws://kaldiws.internal/client/ws/speech');
+const kaldiWsUrl = kaldiDisabled ? null : (opts.kaldiWs || process.env.KALDI_WS_URL || 'ws://kaldiws.internal:2700/client/ws/speech');
 let kaldiSampleRate = parseInt(opts.kaldiSampleRate || process.env.KALDI_SAMPLE_RATE || '16000', 10);
 if (!Number.isFinite(kaldiSampleRate) || kaldiSampleRate <= 0) {
     kaldiSampleRate = 16000;


### PR DESCRIPTION
## Summary
- update the default Kaldi WebSocket endpoint to include port 2700, matching the alphacep/kaldi-fr container configuration
- refresh the README instructions so the documented defaults point to the exposed port

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdb3704cc48324b765f6c193a129b0