### PR TITLE
Adapt transcription storage to legacy schema

### DIFF
--- a/forwarder.js
+++ b/forwarder.js
@@ -99,7 +99,16 @@ class Forwarder {
 
         if (!this.receiver) {
             // créé un AudioReceiver qui enverra tout dans ffmpeg et vers Kaldi
-            this.receiver = new AudioReceiver(this.ffmpeg, 48000, this.logger, this.args.kaldi, this.args.transcriptionStore || null);
+            this.receiver = new AudioReceiver(
+                this.ffmpeg,
+                48000,
+                this.logger,
+                this.args.kaldi,
+                this.args.transcriptionStore || null,
+                { guildId: channel.guild.id, channelId: channel.id }
+            );
+        } else {
+            this.receiver.updateContext(channel.guild.id, channel.id);
         }
 
         // à chaque fois qu’un user parle, on pipe son flux Opus vers notre décodeur

--- a/kaldiClient.js
+++ b/kaldiClient.js
@@ -56,7 +56,7 @@ function downsampleStereo(buffer, inputRate, outputRate) {
 }
 
 class KaldiStream {
-  constructor(userId, config, logger, transcriptionStore) {
+  constructor(userId, config, logger, transcriptionStore, metadata = {}) {
     this.userId = userId;
     this.logger = logger;
     this.config = {
@@ -68,6 +68,10 @@ class KaldiStream {
     this.closed = false;
     this.hasSentConfig = false;
     this.transcriptionStore = transcriptionStore || null;
+    this.metadata = {
+      guildId: metadata?.guildId ?? null,
+      channelId: metadata?.channelId ?? null
+    };
 
     this.ws = new WebSocket(this.config.wsUrl, {
       perMessageDeflate: false
@@ -181,7 +185,7 @@ class KaldiStream {
           this.logger.info(`📝 [Kaldi][${this.userId}] ${transcript}`);
           if (this.transcriptionStore && transcript.trim().length > 0) {
             const confidence = typeof hypothesis.confidence === 'number' ? hypothesis.confidence : null;
-            this.transcriptionStore.saveTranscription(this.userId, transcript, confidence).catch(err => {
+            this.transcriptionStore.saveTranscription(this.userId, transcript, confidence, this.metadata).catch(err => {
               this.logger.error(`❌ [Kaldi] Échec d'enregistrement de la transcription pour ${this.userId}: ${err.message}`);
             });
           }

--- a/webServer.js
+++ b/webServer.js
@@ -27,6 +27,8 @@ function startWebServer(forwarder, port, logger, options = {}) {
 
   const formatRows = rows => rows.map(item => ({
     userId: item.userId,
+    guildId: item.guildId,
+    channelId: item.channelId,
     transcript: item.transcript,
     confidence: item.confidence,
     createdAt: item.createdAt instanceof Date ? item.createdAt.toISOString() : new Date(item.createdAt).toISOString()


### PR DESCRIPTION
## Summary
- update the transcription store to use the existing `voice_transcriptions` schema with `content`/`timestamp` fields and guild/channel identifiers
- propagate guild and channel metadata through the audio receiver and Kaldi stream when saving transcriptions
- expose guild and channel identifiers in the transcription API responses
- log each stored transcription with associated metadata to the console logger

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce9962498883249f949d5fe7a9d872