### PR TITLE
Add voice users API

### DIFF
--- a/webServer.js
+++ b/webServer.js
@@ -34,6 +34,19 @@ function startWebServer(forwarder, port, logger, options = {}) {
     createdAt: item.createdAt instanceof Date ? item.createdAt.toISOString() : new Date(item.createdAt).toISOString()
   }));
 
+  app.get('/api/voice-users', (req, res) => {
+    if (!currentForwarder || typeof currentForwarder.getConnectedUsers !== 'function') {
+      return res.status(503).json({ error: 'Le forwarder n\'est pas prêt.' });
+    }
+    try {
+      const users = currentForwarder.getConnectedUsers();
+      res.json(users);
+    } catch (err) {
+      logger.error(`❌ [API] Impossible de récupérer les utilisateurs vocaux: ${err.message}`);
+      res.status(500).json({ error: 'Erreur interne lors de la récupération des utilisateurs vocaux.' });
+    }
+  });
+
   app.get('/api/transcriptions', async (req, res) => {
     if (!transcriptionStore) {
       return res.status(503).json({ error: 'Le stockage des transcriptions est désactivé.' });


### PR DESCRIPTION
## Summary
- track voice channel members in the forwarder, including mute/deafen status and speaking activity
- expose the new `/api/voice-users` endpoint to retrieve the connected voice member list

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d035053d68832483f8a9c486cefe40