### PR TITLE
Enable CORS for API endpoints

### DIFF
--- a/webServer.js
+++ b/webServer.js
@@ -18,6 +18,16 @@ function startWebServer(forwarder, port, logger, options = {}) {
 
   const app = express();
 
+  app.use((req, res, next) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    if (req.method === 'OPTIONS') {
+      return res.sendStatus(204);
+    }
+    next();
+  });
+
   const parseLimit = (value) => {
     const raw = Array.isArray(value) ? value[0] : value;
     const parsed = parseInt(raw, 10);


### PR DESCRIPTION
## Summary
- add an Express middleware that sets permissive CORS headers on all responses
- handle OPTIONS preflight requests with a 204 status to unblock browsers

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d044a3ae9483248981d4747b0ab81d