### PR TITLE
Ensure voice users API returns up-to-date members

### DIFF
--- a/forwarder.js
+++ b/forwarder.js
@@ -388,7 +388,15 @@ class Forwarder {
             });
     }
 
-    getConnectedUsers() {
+    async getConnectedUsers() {
+        if (this.channel) {
+            try {
+                await this.refreshVoiceUsersFromChannel(this.channel);
+            } catch (err) {
+                this.logger?.warn?.(`⚠️ Impossible d'actualiser les utilisateurs vocaux: ${err.message}`);
+            }
+        }
+
         return Array.from(this.voiceUsers.values()).sort((a, b) => {
             const nameA = a.username || '';
             const nameB = b.username || '';

--- a/webServer.js
+++ b/webServer.js
@@ -44,12 +44,12 @@ function startWebServer(forwarder, port, logger, options = {}) {
     createdAt: item.createdAt instanceof Date ? item.createdAt.toISOString() : new Date(item.createdAt).toISOString()
   }));
 
-  app.get('/api/voice-users', (req, res) => {
+  app.get('/api/voice-users', async (req, res) => {
     if (!currentForwarder || typeof currentForwarder.getConnectedUsers !== 'function') {
       return res.status(503).json({ error: 'Le forwarder n\'est pas prêt.' });
     }
     try {
-      const users = currentForwarder.getConnectedUsers();
+      const users = await currentForwarder.getConnectedUsers();
       res.json(users);
     } catch (err) {
       logger.error(`❌ [API] Impossible de récupérer les utilisateurs vocaux: ${err.message}`);


### PR DESCRIPTION
## Summary
- refresh the forwarder's voice user cache before returning connected members
- await the asynchronous refresh inside the /api/voice-users endpoint so it returns the full set

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d051dc34448324889404201f52d0f7