### PR TITLE
Expose voice users API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,17 @@ demande une connexion chiffrée. La table `voice_transcriptions` est créée
 automatiquement si elle n’existe pas.
 
 Une API REST est exposée sur le même port que l’interface web (ou sur `--web-port` si
-vous n’activez pas l’interface). Deux endpoints sont disponibles :
+vous n’activez pas l’interface). Les endpoints suivants sont disponibles :
 
+- `GET /api/voice-users` renvoie la liste actuelle des utilisateurs connectés au
+  salon vocal ciblé, avec leur état micro/casque et l’indication s’ils parlent.
 - `GET /api/transcriptions?limit=50` retourne les dernières transcriptions tous
   utilisateurs confondus (limite maximale : 200).
 - `GET /api/transcriptions/:userId?limit=50` renvoie les dernières transcriptions
   associées à un utilisateur précis.
+
+L’API est activée par défaut, mais vous pouvez la désactiver avec l’option
+`--no-api` si vous ne souhaitez exposer aucune route HTTP.
 
 The white-noise generator in `audioReceiver.js` writes very low-level samples
 (amplitude around `±100`). Adjust this constant if you need the noise to be

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ program
     .option('--kaldi-disable', 'Désactive la retranscription Kaldi')
     .option('--pg-url <url>', 'URL de connexion Postgres', process.env.POSTGRES_URL || process.env.DATABASE_URL)
     .option('--pg-ssl', 'Active SSL pour la connexion Postgres')
+    .option('--no-api', 'Désactive l\'API HTTP')
     .argument('[icecastUrl]', 'URL Icecast de destination')
     .argument('[fileOutput]', 'Chemin de fichier local en alternative')
     .parse(process.argv);
@@ -75,6 +76,7 @@ const args = {
     listeningTo: opts.listeningTo,
     web: opts.web,
     webPort: parseInt(opts.webPort, 10),
+    api: opts.api !== false,
     kaldi: kaldiWsUrl ? {
         wsUrl: kaldiWsUrl,
         sampleRate: kaldiSampleRate,
@@ -97,10 +99,11 @@ let forwarder;
 let webServerController = null;
 
 function ensureWebServer() {
-    if (!webServerController && (args.web || args.transcriptionStore)) {
+    if (!webServerController && (args.api || args.web || args.transcriptionStore)) {
         webServerController = startWebServer(forwarder, args.webPort, logger, {
             enableWebClient: args.web,
-            transcriptionStore: args.transcriptionStore || null
+            transcriptionStore: args.transcriptionStore || null,
+            enableVoiceApi: args.api
         });
     } else if (webServerController) {
         webServerController.updateForwarder(forwarder);


### PR DESCRIPTION
## Summary
- expose an HTTP endpoint that lists the users currently connected to the voice channel and prevent responses from being cached
- start the web server whenever the API is enabled, with a `--no-api` option to turn it off
- document the new voice user endpoint and the API toggle in the README

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d0617c347483248d6307d41a68942a